### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
-server/node_modules
-client/client/node_modules
-client/client/configs
-client/dist
-server/configs
-server/uploads
-old_client
+node_modules
+configs
+dist
 uploads
+old_client
 prod


### PR DESCRIPTION
if you do not specify where the folder is, it will ignore all of them. For examples `server/node_modules` only ignores that `node_modules`. But, if the gitignore has `node_modules` without a parent directory, you will ignore **all** folders with the name `node_modules`. This also reads more easily